### PR TITLE
Remove melodic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ The source code is released under an [Apache 2.0].
 
 ### Supported ROS Distributions
 - Kinetic
-- Melodic
 
 ## Installation
 


### PR DESCRIPTION
A dependency of this example (`mqtt_bridge`) hasn't been released for melodic yet so these instruction will only work in Kinetic.

*Issue #, if available:*
Issue noticed in https://github.com/aws-robotics/aws-iot-bridge-example/issues/3

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
