### PR TITLE
Fix dependencies in package.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The source code is released under an [Apache 2.0].
 ### Supported ROS Distributions
 - Kinetic
 
+
 ## Installation
 
 ### IoT Device Certificate
@@ -31,7 +32,7 @@ To build from source you'll need to create a new workspace, clone and checkout t
 
 - Create a ROS workspace and a source directory
 
-    mkdir -p ~/ros-workspace/src
+        mkdir -p ~/ros-workspace/src
 
 - Clone the package into the source directory . 
 
@@ -57,15 +58,15 @@ _Note: If building the master branch instead of a release branch you may need to
         source ~/ros-workspace/install/setup.bash
 
 
-
 ## Launch Files
 An example launch file called `aws_iot_bridge.launch` is provided, however the launch file cannot work without proper configuration. Since AWS IoT uses unique endpoints and certificates for each account and device, you must first discover your AWS IoT endpoint and generate a certificate before you can connect.
+
 
 ## Usage
 
 ### Run the node
 - **With** launch file using parameters in .yaml format (need to be configured first)
-  - ROS: `roslaunch aws_iot_mqtt_bridge aws_iot_bridge.launch bridge_params:=config/example_aws_iot_params.yaml`
+  - ROS: `roslaunch aws_iot_mqtt_bridge aws_iot_bridge.launch bridge_params:=<path>/config/example_aws_iot_params.yaml`
 
 - **Without** launch file using default values
   - ROS: `rosrun mqtt_bridge mqtt_bridge_node.py`
@@ -77,6 +78,7 @@ An example launch file called `aws_iot_bridge.launch` is provided, however the l
 - Select `Test` from the menu on the left side of the screen
 - Type the name of one of the configured topics and click `Subscribe to topic`
 - You should see messages begin appearing in the bottom half of the screen
+
 
 ## Configuration File and Parameters
 An example configuration file called `example_aws_iot_params.yaml` is provided. When the parameters are absent in the ROS parameter server, the mqtt_bridge will use defaults, please refer to the [mqtt_bridge] package.
@@ -92,6 +94,7 @@ An example configuration file called `example_aws_iot_params.yaml` is provided. 
 | connection/port | Port to use when connecting to AWS IoT core (default is 8883) | *int* | A valid port number (1-65535) |
 | connection/keepalive | TCP connection keep-alive | *int* | Number of seconds greater than zero |
 | client/protocol | MQTT protocol to use when connecting (default is MQTT311 or 4) | *int* | Valid protocol number |
+
 
 ## Node
 

--- a/aws_iot_mqtt_bridge/package.xml
+++ b/aws_iot_mqtt_bridge/package.xml
@@ -16,6 +16,6 @@
   <depend>mosquitto-clients</depend>
   <depend>python-inject-pip</depend>
   <depend>python-paho-mqtt-pip</depend>
-  <depend>msgpack-python-pip</depend>
-  <depend>pymongo-pip</depend>
+  <depend>python-msgpack</depend>
+  <depend>python-pymongo</depend>
 </package>


### PR DESCRIPTION
*Description of changes:*

The dependencies listed in the `package.xml` files are incorrect (they do no follow a `python-<package name>-pip` pattern).

It also looks like the `bridge_params` argument passed to the `.launch` file needs to be an absolute path or a path relative to the current working directory, not relative to the installed package `share` directory, so the README should be updated to reflect that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
